### PR TITLE
fix test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc_tools"
-version = "0.1.1"
+version = "0.1.3"
 authors = ["lovebaihezi <x18739168862@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,42 @@
+use std::{error::Error, ptr::null_mut};
+
+use libc::*;
+use libc_tools::Pty;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let pty = Pty::new(null_mut::<termios>(), null_mut::<winsize>()).unwrap();
+    println!(
+        "{}",
+        match &pty.device_name {
+            Some(v) => v.clone(),
+            None => panic!(""),
+        }
+    );
+    unsafe {
+        write(
+            pty.pty_fd.unwrap(),
+            "date \n\0".as_ptr() as *const c_void,
+            7,
+        )
+    };
+    let mut buf = [0 as u8; 4096];
+    let mut read_size;
+    let mut index = 0;
+    while unsafe {
+        read_size = read(pty.pty_fd.unwrap(), buf.as_mut_ptr() as *mut c_void, 4096);
+        read_size != 0 && read_size != -1 && index <= 3
+    } {
+        index += 1;
+        assert!(read_size != -1 && read_size != 0);
+        for i in &buf[..read_size as usize] {
+            print!("{}", *i as char);
+        }
+        println!("");
+    }
+    for i in &buf[..read_size as usize] {
+        print!("{}", *i as char);
+    }
+    println!("");
+    // pty.drop()?;
+    Ok(())
+}


### PR DESCRIPTION
When I test pty fork, the cargo test will exit when test all finished, cargo test, main shell, and debug out will wait for pty device "zsh -i"(see pty.rs) children process exit, but cargo test would exit as test finished, so it will suspend to wait for children, as Drop trait is close the fd, and wait for "zsh -i" to exit, then main shell will become suspend.So, test the pty should use a binary